### PR TITLE
add docker image + build in CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+*
+
+!/src/
+!/LICENSE
+!/package-lock.json
+!/package.json
+!/README.md
+!/tsconfig.json
+
+/src/version.ts

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,42 @@
+name: docker
+
+on:
+  push:
+    tags:
+      - '*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:18-bullseye
+
+RUN apt-get -y update \
+    && apt-get -y install tini \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+WORKDIR "/srv"
+
+COPY package.json package-lock.json tsconfig.json ./
+COPY src ./src
+
+RUN npm install
+RUN npm run build
+
+ENV NODE_ENV="production"
+
+EXPOSE 3000/tcp
+VOLUME ["/root/.npm", "/root/.rgb-proxy-server"]
+
+CMD ["tini", "--", "npm", "run", "start"]

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "tsc",
     "lint": "eslint --ignore-path .gitignore . --ext .ts",
     "lint:fix": "npm run lint -- --fix",
+    "pretest": "npm run version",
     "test": "jest --verbose",
     "version": "echo 'export const APP_VERSION = \"'$npm_package_version'\"' > src/version.ts"
   },


### PR DESCRIPTION
This PR adds a Dockerfile to build a docker image for the proxy server and a GitHub workflow to build and publish it to the GitHub Container Registry.

The GH workflow is set to run on tags only, so pushing a tag (e.g. `0.1.0`) will publish a docker image that can be pulled with `docker pull ghcr.io/grunch/rgb-proxy-server:0.1.0`.

A fix for the test workflow is also included, so now all workflows should pass.

Let me know if there's anything you want to discuss or change.