### PR TITLE
Run `chown -R root:root /srv` in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,9 @@ WORKDIR "/srv"
 COPY package.json package-lock.json tsconfig.json ./
 COPY src ./src
 
-RUN npm install
-RUN npm run build
+RUN npm install \
+ && npm run build \
+ && chown -R root:root /srv
 
 ENV NODE_ENV="production"
 


### PR DESCRIPTION
This fix will avoid a issue in pulling the image on arm64 based
instances.

I got `ERROR: failed to register layer: ApplyLayer exit status 1 stdout:  stderr: failed to Lchown` on my Unbrel OS instance.
Even though it might be reproduced on `arm64` only, I supporse there is no regression on `amd64` by calling `chown` in `docker build`.
