### PR TITLE
Use `cors` to allow request from any origin.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,11 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "rgb-proxy-server",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "cors": "^2.8.5",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
         "express-http-context": "^1.2.4",
@@ -19,6 +21,7 @@
         "winston": "^3.8.2"
       },
       "devDependencies": {
+        "@types/cors": "^2.8.13",
         "@types/express": "^4.17.15",
         "@types/jest": "^29.2.4",
         "@types/morgan": "^1.9.3",
@@ -1352,6 +1355,15 @@
       "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
       "dev": true
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.13",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
+      "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/express": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.15.tgz",
@@ -2559,6 +2571,18 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -8320,6 +8344,15 @@
       "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
       "dev": true
     },
+    "@types/cors": {
+      "version": "2.8.13",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
+      "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/express": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.15.tgz",
@@ -9251,6 +9284,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
     },
     "create-require": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "@types/cors": "^2.8.13",
     "@types/express": "^4.17.15",
     "@types/jest": "^29.2.4",
     "@types/morgan": "^1.9.3",
@@ -41,6 +42,7 @@
     "typescript": "^4.9.4"
   },
   "dependencies": {
+    "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "express-http-context": "^1.2.4",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,3 +1,4 @@
+import cors from "cors";
 import express from "express";
 import httpContext from "express-http-context";
 import morgan from "morgan";
@@ -14,6 +15,9 @@ const app = express();
 
 // Create app directory if it doesn't exist
 setDir(path.join(homedir(), APP_DIR));
+
+// Allow request from any origin
+app.use(cors());
 
 app.use(httpContext.middleware);
 


### PR DESCRIPTION
When building a very simple front end for this server, I noticed that the proxy server does not accept the request from a browser when the HTML is served from a different server.
This change will solve the issue. And since I don't see any security concern with this change, I also share it here.